### PR TITLE
 feat: GitHub Pagesでの自動公開に対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  base: '/astute-crow/',
   server: {
     port: 3000,
     open: true,


### PR DESCRIPTION
## 概要
  プロジェクトをGitHub
  Pagesで公開できるよう、必要な設定とワークフローを追加しました。

  ## 変更内容

  ### 🚀 GitHub Pages対応
  - Vite設定にbase URL（`/astute-crow/`）を追加
  - GitHub Pagesのサブディレクトリでの正しいアセットパス参照を実現

  ### ⚙️ 自動デプロイ設定
  - GitHub Actions ワークフローを作成（`.github/workflows/deploy.yml`）
  - mainブランチへのプッシュ時に自動ビルド・デプロイ
  - Node.js v22（LTS）を使用してビルド環境を最新化

  ## 動作確認
  - [x] ローカルでのビルドが正常に完了することを確認
  - [x] 生成されたHTMLでアセットパスが正しく設定されることを確認

  ## 公開後のURL
  https://mrsmart00.github.io/astute-crow/

  ## 注意事項
  - マージ後、GitHub リポジトリの Settings > Pages で「GitHub
  Actions」を選択する必要があります
  - 初回デプロイ後にサイトが表示されるまで数分かかる場合があります

  ## レビューポイント
  - GitHub Actions ワークフローの設定
  - Viteのbase URL設定が適切かどうか

🤖 Generated with [Claude Code](https://claude.ai/code)