### PR TITLE
fix: GitHub Pages環境でのZenn API接続エラーを修正

### DIFF
--- a/src/services/zennService.ts
+++ b/src/services/zennService.ts
@@ -73,7 +73,7 @@ const mockPosts: ZennPost[] = [
 
 class ZennService {
   private async fetchTechArticles(): Promise<ZennArticle[]> {
-    const response = await fetch('/api/zenn/trendTech');
+    const response = await fetch('https://zenn-api.vercel.app/api/trendTech');
     if (!response.ok) {
       throw new Error(`Tech API request failed: ${response.status}`);
     }
@@ -86,7 +86,7 @@ class ZennService {
   }
 
   private async fetchIdeaArticles(): Promise<ZennArticle[]> {
-    const response = await fetch('/api/zenn/trendIdea');
+    const response = await fetch('https://zenn-api.vercel.app/api/trendIdea');
     if (!response.ok) {
       throw new Error(`Idea API request failed: ${response.status}`);
     }
@@ -99,7 +99,7 @@ class ZennService {
   }
 
   private async fetchBooks(): Promise<ZennBook[]> {
-    const response = await fetch('/api/zenn/trendBook');
+    const response = await fetch('https://zenn-api.vercel.app/api/trendBook');
     if (!response.ok) {
       throw new Error(`Book API request failed: ${response.status}`);
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,14 +4,7 @@ export default defineConfig({
   base: '/astute-crow/',
   server: {
     port: 3000,
-    open: true,
-    proxy: {
-      '/api/zenn': {
-        target: 'https://zenn-api.vercel.app',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api\/zenn/, '/api')
-      }
-    }
+    open: true
   },
   build: {
     target: 'esnext',


### PR DESCRIPTION
## 概要
  GitHub PagesでZenn記事が取得できない問題を修正しました。

  ## 問題
  - GitHub Pages（静的ホスティング）でプロキシ設定が動作しない
  - `/api/zenn/*`へのリクエストが404エラーになる
  - 開発環境と本番環境で異なる動作

  ## 解決策
  - Zenn APIへの直接アクセスに変更
  - プロキシ設定を削除し、開発・本番で同一の動作を実現
  - CORS対応済み（Zenn APIが`Access-Control-Allow-Origin: *`を返す）

  ## 変更内容
  - `src/services/zennService.ts`: API URLを絶対パスに変更
  - `vite.config.ts`: プロキシ設定を削除

  ## テスト
  - [x] ローカル開発環境での動作確認
  - [x] ビルド成功確認
  - [x] プレビューサーバーでの動作確認
  - [ ] GitHub Pagesでの動作確認（デプロイ後）

  🤖 Generated with [Claude Code](https://claude.ai/code)